### PR TITLE
Added leader election method + CreateBucket

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,5 +9,6 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/relistan/go-director v0.0.0-20200406104025-dbbf5d95248d
 	github.com/satori/go.uuid v1.2.0
+	github.com/sirupsen/logrus v1.7.0 // indirect
 	gopkg.in/DataDog/dd-trace-go.v1 v1.37.1
 )

--- a/go.sum
+++ b/go.sum
@@ -627,6 +627,7 @@ github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2/go.mod h1:pMByvH
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v1.0.1/go.mod h1:kHHU4qYBaI3q23Pp3VPrmWhuIUrLW/7eUrw0BU5VaoM=

--- a/leader.go
+++ b/leader.go
@@ -1,0 +1,211 @@
+package natty
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/relistan/go-director"
+)
+
+const (
+	DefaultBucketTTl       = time.Second * 10
+	ElectionLooperInterval = time.Second * 3
+)
+
+var (
+	ErrBucketTTLMismatch = errors.New("bucket ttl mismatch")
+)
+
+type AsLeaderConfig struct {
+	// Looper is the loop construct that will be used to execute Func (required)
+	Looper director.Looper
+
+	// Bucket specifies what K/V bucket will be used for leader election (required)
+	Bucket string
+
+	// NodeName is the name used for this node (should be unique in cluster) (optional)
+	NodeName string
+
+	// BucketTTL specifies the TTL of values in the bucket (optional; default = 10s)
+	BucketTTL time.Duration
+
+	// ElectionLooper specifies the loop construct that will be used to perform leader election attempts (optional)
+	ElectionLooper director.Looper
+
+	// Description will set the bucket description (optional)
+	Description string
+
+	// Internal fields
+	haveLeader bool
+}
+
+func (n *Natty) AsLeader(ctx context.Context, cfg *AsLeaderConfig, f func() error) error {
+	if err := validateAsLeaderConfig(cfg); err != nil {
+		return errors.Wrap(err, "unable to validate AsLeaderConfig")
+	}
+
+	if f == nil {
+		return errors.New("func is required")
+	}
+
+	// Attempt to create bucket; if bucket exists, verify that TTL matches
+	if err := n.CreateBucket(ctx, cfg.Bucket, cfg.BucketTTL, cfg.Description); err != nil {
+		if strings.Contains(err.Error(), "stream name already in use") {
+			n.log.Debug("bucket exists, checking if ttl matches")
+
+			kv, err := n.js.KeyValue(cfg.Bucket)
+			if err != nil {
+				return errors.Wrap(err, "unable to fetch existing bucket")
+			}
+
+			s, err := kv.Status()
+			if err != nil {
+				return errors.Wrap(err, "unable to fetch existing bucket status")
+			}
+
+			n.log.Debugf("ttl on bucket: %v desired ttl: %v", s.TTL(), cfg.BucketTTL)
+
+			if s.TTL().Seconds() != cfg.BucketTTL.Seconds() {
+				n.log.Error("bucket ttls do not match")
+				return ErrBucketTTLMismatch
+			}
+		} else {
+			return errors.Wrap(err, "unable to pre-create leader bucket")
+		}
+	}
+
+	errCh := make(chan error, 1)
+
+	n.log.Debugf("%s: starting leader election goroutine", cfg.NodeName)
+
+	// Launch leader election in goroutine (leader election goroutine should quit when AsLeader is cancelled or exits)
+	go func() {
+		err := n.runLeaderElection(ctx, cfg)
+		if err != nil {
+			n.log.Errorf("%s: unable to run leader election: %v", cfg.NodeName, err)
+			errCh <- err
+
+			return
+		}
+	}()
+
+	n.log.Debugf("%s: waiting for goroutine to not error", cfg.NodeName)
+
+	select {
+	case err := <-errCh:
+		return errors.Wrap(err, "ran into error during leader election startup")
+	case <-ctx.Done():
+		return errors.New("context cancelled - leader election cancelled")
+		// Leader election did not error after 2 seconds, all is well
+	case <-time.After(time.Second * 1):
+		break
+	}
+
+	// Leader election goroutine started; run main loop
+	n.log.Debugf("%s: leader election goroutine started; running main loop", cfg.NodeName)
+
+	cfg.Looper.Loop(func() error {
+		if !cfg.haveLeader {
+			n.log.Debugf("%s: AsLeader: not leader", cfg.NodeName)
+			return nil
+		}
+
+		n.log.Debugf("%s: AsLeader: running func", cfg.NodeName)
+
+		// Have leader, exec func
+		if err := f(); err != nil {
+			n.log.Errorf("%s: error during func execution: %v", cfg.NodeName, err)
+			return nil
+		}
+
+		return nil
+	})
+
+	return nil
+}
+
+func (n *Natty) runLeaderElection(ctx context.Context, cfg *AsLeaderConfig) error {
+	var quit bool
+
+	cfg.ElectionLooper.Loop(func() error {
+		// We are supposed to quit - give looper time to react to quit
+		if quit {
+			time.Sleep(time.Second)
+			return nil
+		}
+
+		// NATS K/V client does not support ctx yet so we do it here instead
+		select {
+		case <-ctx.Done():
+			n.log.Debugf("%s: context cancelled, exiting leader election", cfg.NodeName)
+			quit = true
+			cfg.ElectionLooper.Quit()
+
+			return nil
+		default:
+			// Continue
+		}
+
+		// Have leader - attempt to update key to increase TTL
+		if cfg.haveLeader {
+			if err := n.Put(ctx, cfg.Bucket, "leader", []byte(cfg.NodeName)); err != nil {
+				n.log.Errorf("%s: unable to update leader key: %v", cfg.NodeName, err)
+				cfg.haveLeader = false
+
+				return nil
+			}
+
+			n.log.Debugf("%s: updated leader key", cfg.NodeName)
+
+			return nil
+		}
+
+		if err := n.Create(ctx, cfg.Bucket, "leader", []byte(cfg.NodeName)); err != nil {
+			if strings.Contains(err.Error(), "wrong last sequence") {
+				n.log.Debugf("%s: leader key already exists, ignoring", cfg.NodeName)
+				return nil
+			}
+
+			n.log.Errorf("%s: unable to create leader key: %v", cfg.NodeName, err)
+
+			return nil
+		}
+
+		n.log.Debugf("%s: leader key created", cfg.NodeName)
+
+		// Have leader
+		cfg.haveLeader = true
+
+		return nil
+	})
+
+	n.log.Debugf("%s: leader election goroutine exiting", cfg.NodeName)
+
+	return nil
+}
+
+func validateAsLeaderConfig(cfg *AsLeaderConfig) error {
+	if cfg == nil {
+		return errors.New("AsLeaderConfig is required")
+	}
+
+	if cfg.Looper == nil {
+		return errors.New("Looper is required")
+	}
+
+	if cfg.Bucket == "" {
+		return errors.New("Bucket is required")
+	}
+
+	if cfg.BucketTTL == 0 {
+		cfg.BucketTTL = DefaultBucketTTl
+	}
+
+	if cfg.ElectionLooper == nil {
+		cfg.ElectionLooper = director.NewTimedLooper(director.FOREVER, ElectionLooperInterval, make(chan error, 1))
+	}
+
+	return nil
+}

--- a/leader_test.go
+++ b/leader_test.go
@@ -1,0 +1,301 @@
+// NOTE: These tests require NATS to be available on "localhost"
+package natty
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/relistan/go-director"
+	uuid "github.com/satori/go.uuid"
+)
+
+var (
+	usedBuckets = make([]string, 0)
+)
+
+var _ = Describe("KV", func() {
+	var (
+		cfg *Config
+		n   *Natty
+	)
+
+	BeforeEach(func() {
+		var beforeEachErr error
+
+		cfg = NewConfig()
+
+		// Enable for test debug
+		//logger := logrus.New()
+		//logger.Level = logrus.DebugLevel
+		//cfg.Logger = logger
+
+		n, beforeEachErr = New(cfg)
+
+		Expect(beforeEachErr).To(BeNil())
+		Expect(n).NotTo(BeNil())
+	})
+
+	AfterEach(func() {
+		err := CleanupBuckets(usedBuckets)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Describe("AsLeader", func() {
+		It("should error with bad config", func() {
+			cfg := NewAsLeaderConfig("batman", uuid.NewV4().String())
+
+			err := n.AsLeader(context.Background(), nil, nil)
+			Expect(err.Error()).To(ContainSubstring("AsLeaderConfig is required"))
+
+			err = n.AsLeader(context.Background(), cfg, nil)
+			Expect(err.Error()).To(ContainSubstring("func is required"))
+
+		})
+
+		It("should exec func when leader", func() {
+			executedBy := make([]string, 0)
+
+			errChan := make(chan error, 10)
+			cancelCtx, cancel := context.WithCancel(context.Background())
+			bucketName := uuid.NewV4().String()
+
+			for i := 0; i < 3; i++ {
+				cfg := NewAsLeaderConfig(fmt.Sprintf("node-%d", i), bucketName)
+
+				go func() {
+					defer GinkgoRecover()
+
+					err := n.AsLeader(cancelCtx, cfg, func() error {
+						executedBy = append(executedBy, cfg.NodeName)
+						return nil
+					})
+
+					if err != nil {
+						errChan <- err
+					}
+				}()
+			}
+
+			// Expect for AsLeader to not error for 2s
+			Consistently(errChan, "2s").ShouldNot(Receive())
+
+			// Shutdown goroutines
+			cancel()
+
+			// Timing exactly how many times exec func would be called is difficult
+			// to predict as it can be affected by CPU load (and probably other factors).
+			// Best we can do is expect that it has happened at least a couple of times.
+			Expect(len(executedBy)).To(BeNumerically(">=", 2))
+
+			// Ensure that same leader has always executed func
+			var expectedNode string
+
+			for _, v := range executedBy {
+				if expectedNode == "" {
+					expectedNode = v
+					continue
+				}
+
+				Expect(expectedNode).To(Equal(v))
+			}
+
+			// For good measure, verify that expectedNode is actually set
+			Expect(expectedNode).ToNot(BeEmpty())
+		})
+
+		It("should not exec function when not leader", func() {
+			// Get leader
+			iran := false
+
+			errChan := make(chan error, 10)
+			cancelCtx, cancel := context.WithCancel(context.Background())
+			bucketName := uuid.NewV4().String()
+
+			cfg := NewAsLeaderConfig("node-1", bucketName)
+
+			go func() {
+				defer GinkgoRecover()
+
+				err := n.AsLeader(cancelCtx, cfg, func() error {
+					iran = true
+					return nil
+				})
+
+				if err != nil {
+					errChan <- err
+				}
+			}()
+
+			// Leader should not error for 2s
+			Consistently(errChan, "2s").ShouldNot(Receive())
+
+			// Expect that leader has ran func
+			Expect(iran).To(BeTrue())
+
+			/////////////// Node #2 //////////////////////
+
+			// Start another AsLeader
+			var iran2 bool
+
+			cfg2 := NewAsLeaderConfig("node-2", bucketName)
+			errChan2 := make(chan error, 10)
+
+			go func() {
+				defer GinkgoRecover()
+
+				err := n.AsLeader(cancelCtx, cfg2, func() error {
+					iran2 = true
+					return nil
+				})
+
+				if err != nil {
+					errChan2 <- err
+				}
+			}()
+
+			// Verify that 2nd node has not emitted errors
+			Consistently(errChan2, "2s").ShouldNot(Receive())
+
+			// Verify that 2nd AsLeader hasn't executed func
+			Expect(iran2).To(BeFalse())
+
+			// Stop all goroutines
+			cancel()
+		})
+
+		It("should auto-create bucket", func() {
+			// Verify bucket doesn't exist
+			bucketName := uuid.NewV4().String()
+
+			kv, err := n.js.KeyValue(bucketName)
+			Expect(err).To(Equal(nats.ErrBucketNotFound))
+			Expect(kv).To(BeNil())
+
+			// Start AsLeader
+			errChan := make(chan error, 10)
+			cancelCtx, cancel := context.WithCancel(context.Background())
+
+			cfg := NewAsLeaderConfig("node-1", bucketName)
+
+			go func() {
+				defer GinkgoRecover()
+
+				err := n.AsLeader(cancelCtx, cfg, func() error {
+					return nil
+				})
+
+				if err != nil {
+					errChan <- err
+				}
+			}()
+
+			// Leader should not error for 2s
+			Consistently(errChan, "2s").ShouldNot(Receive())
+
+			cancel()
+
+			// Verify bucket exists
+			kv, err = n.js.KeyValue(bucketName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(kv).ToNot(BeNil())
+		})
+
+		It("should work with existing bucket and same TTL", func() {
+			bucketName := uuid.NewV4().String()
+			bucketTTL := 321 * time.Second
+
+			// Create bucket manually with TTL
+			kv, err := n.js.CreateKeyValue(&nats.KeyValueConfig{
+				Bucket:      bucketName,
+				Description: "AsLeader bucket auto-create test",
+				TTL:         bucketTTL,
+			})
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(kv).ToNot(BeNil())
+
+			// Start AsLeader with same TTL <- shouldn't error
+			errChan := make(chan error, 10)
+			cancelCtx, cancel := context.WithCancel(context.Background())
+
+			cfg := NewAsLeaderConfig("node-1", bucketName)
+			cfg.BucketTTL = bucketTTL
+
+			go func() {
+				defer GinkgoRecover()
+
+				err := n.AsLeader(cancelCtx, cfg, func() error {
+					return nil
+				})
+
+				if err != nil {
+					n.log.Debugf("AsLeader error: %v", err)
+					errChan <- err
+				}
+			}()
+
+			// Leader should not error for 2s
+			Consistently(errChan, "2s").ShouldNot(Receive())
+
+			cancel()
+		})
+
+		It("should error when pre-existing bucket has different TTL", func() {
+			bucketName := uuid.NewV4().String()
+			bucketTTL := 321 * time.Second
+
+			// Create bucket manually with TTL
+			kv, err := n.js.CreateKeyValue(&nats.KeyValueConfig{
+				Bucket:      bucketName,
+				Description: "AsLeader bucket auto-create test",
+				TTL:         bucketTTL,
+			})
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(kv).ToNot(BeNil())
+
+			// Start AsLeader with same TTL <- shouldn't error
+			var errorHasOccurred error
+			cancelCtx, cancel := context.WithCancel(context.Background())
+			errChan := make(chan error, 10)
+
+			cfg := NewAsLeaderConfig("node-1", bucketName)
+			cfg.BucketTTL = time.Second * 123456789
+
+			go func() {
+				errorHasOccurred = n.AsLeader(cancelCtx, cfg, func() error {
+					return nil
+				})
+
+				if errorHasOccurred != nil {
+					errChan <- errorHasOccurred
+				}
+			}()
+
+			// We should get an error
+			Eventually(errChan, "2s").Should(Receive(MatchError(ErrBucketTTLMismatch)))
+
+			cancel()
+
+		})
+	})
+})
+
+func NewAsLeaderConfig(nodeName string, bucketName string) *AsLeaderConfig {
+	cfg := &AsLeaderConfig{
+		Bucket:         bucketName,
+		Description:    "AsLeader test",
+		BucketTTL:      time.Second * 10,
+		NodeName:       nodeName,
+		Looper:         director.NewTimedLooper(director.FOREVER, 200*time.Millisecond, make(chan error, 1)),
+		ElectionLooper: director.NewTimedLooper(director.FOREVER, 100*time.Millisecond, make(chan error, 1)),
+	}
+
+	usedBuckets = append(usedBuckets, cfg.Bucket)
+
+	return cfg
+}

--- a/natty.go
+++ b/natty.go
@@ -84,11 +84,22 @@ type INatty interface {
 	// or key does not exist.
 	Delete(ctx context.Context, bucket string, key string) error
 
+	// CreateBucket will attempt to create a new bucket. Will return an error if
+	// bucket already exists.
+	CreateBucket(ctx context.Context, bucket string, ttl time.Duration, description ...string) error
+
 	// DeleteBucket will delete the specified bucket
 	DeleteBucket(ctx context.Context, bucket string) error
 
 	// Keys will return all of the keys in a bucket (empty slice if none found)
 	Keys(ctx context.Context, bucket string) ([]string, error)
+
+	// AsLeader enables simple leader election by using NATS k/v functionality.
+	//
+	// AsLeader will execute opts.Func if and only if the node executing AsLeader
+	// acquires leader role. It will continue executing opts.Func until it loses
+	// leadership and another node becomes leader.
+	AsLeader(ctx context.Context, opts *AsLeaderConfig, f func() error) error
 }
 
 type Config struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -93,6 +93,8 @@ github.com/relistan/go-director
 # github.com/satori/go.uuid v1.2.0
 ## explicit
 github.com/satori/go.uuid
+# github.com/sirupsen/logrus v1.7.0
+## explicit
 # github.com/tinylib/msgp v1.1.2
 github.com/tinylib/msgp/msgp
 # golang.org/x/crypto v0.0.0-20210921155107-089bfa567519


### PR DESCRIPTION
@blinktag @brainsnail 

It should now be possible to do AsLeader(ctx, cfg, func() error { ... }) and the func will be executed only as a leader. 

The flow is simple:

Multiple nodes attempt to create the same key "leader" under the leader bucket that is specified in cfg.
Only one node will succeed because `Create` will error if a key already exists.
Node that succeeds at Create is the leader and will continue to `Put` the key which will refresh the key's TTL.
If current leader goes away, TTL will expire and the key will disappear.
Another leader will emerge because their `Create` call will succeed.

Fully tested.